### PR TITLE
Update Hadoop-MapReduce.md

### DIFF
--- a/notes/Hadoop-MapReduce.md
+++ b/notes/Hadoop-MapReduce.md
@@ -54,7 +54,7 @@ MapReduce 编程模型中 `splitting` 和 `shuffing` 操作都是由框架实现
 
 ### 3.1 InputFormat & RecordReaders 
 
-`InputFormat` 将输出文件拆分为多个 `InputSplit`，并由 `RecordReaders` 将 `InputSplit` 转换为标准的<key，value>键值对，作为 map 的输出。这一步的意义在于只有先进行逻辑拆分并转为标准的键值对格式后，才能为多个 `map` 提供输入，以便进行并行处理。
+`InputFormat` 将输出文件拆分为多个 `InputSplit`，并由 `RecordReaders` 将 `InputSplit` 转换为标准的<key，value>键值对，作为 map 的输入。这一步的意义在于只有先进行逻辑拆分并转为标准的键值对格式后，才能为多个 `map` 提供输入，以便进行并行处理。
 
 
 


### PR DESCRIPTION
发现一处笔误，原文：InputFormat将输出文件拆分为多个InputSplit，并由RecordReaders将InputSplit转换为标准的<key，value>键值对，作为map的输出。 此处应为map的输入